### PR TITLE
Return "FAILED" instead of "FAIL" if check failed

### DIFF
--- a/report.go
+++ b/report.go
@@ -53,7 +53,7 @@ func buildRunReport(results []*Result) runReport {
 
 func statusLabel(ok bool) string {
 	if !ok {
-		return "FAIL"
+		return "FAILED"
 	}
 	return "OK"
 }


### PR DESCRIPTION
This way we are consistent with the JAVA version.
