### PR TITLE
Add metadata to reporters

### DIFF
--- a/html_reporter.go
+++ b/html_reporter.go
@@ -80,7 +80,7 @@ var htmlTemplate = template.Must(template.New("Page").Parse(`
 	</table>
 	
 	<h4>
-		Checks:{{.TotalCount}}, Failures:{{.FailedCount}}, Time:{{.CompletedIn}} |
+		Checks: {{.TotalCount}}, Failures: {{.FailedCount}}, Time: {{.CompletedIn}} |
 		go-selfdiagnose {{.Version}} | <a href="?format=xml">XML</a>| <a href="?format=json">JSON</a> | since:{{.Since.Format "2006-01-02 3:04"}} report:{{.ReportDate.Format "2006-01-02 3:04"}} </td>
 	</h4>
 </body>

--- a/report.go
+++ b/report.go
@@ -11,9 +11,9 @@ import (
 )
 
 type runReport struct {
-	SelfDiagnose map[string]string `json:"selfdiagnose" `
-	Run          time.Time         `json:"run" `
-	Results      []taskReport      `json:"results" `
+	SelfDiagnose map[string]interface{} `json:"selfdiagnose" `
+	Run          time.Time              `json:"run" `
+	Results      []taskReport           `json:"results" `
 }
 
 type taskReport struct {
@@ -40,11 +40,14 @@ func buildTaskReports(results []*Result) (list []taskReport) {
 }
 
 func buildRunReport(results []*Result) runReport {
+	c, f := checksAndFailures(results)
 	return runReport{
-		SelfDiagnose: map[string]string{
+		SelfDiagnose: map[string]interface{}{
 			"version":     VERSION,
 			"since":       since.String(),
 			"completedIn": toMillisecondsString(totalDuration(results)),
+			"checks":      c,
+			"failures":    f,
 		},
 		Run:     time.Now(),
 		Results: buildTaskReports(results),
@@ -67,4 +70,14 @@ func totalDuration(results []*Result) (total time.Duration) {
 
 func toMillisecondsString(d time.Duration) string {
 	return strconv.FormatInt(d.Nanoseconds()/1000000, 10) // ms
+}
+
+func checksAndFailures(results []*Result) (checks, failures int) {
+	for _, r := range results {
+		checks++
+		if !r.Passed {
+			failures++
+		}
+	}
+	return
 }

--- a/xml_reporter.go
+++ b/xml_reporter.go
@@ -17,12 +17,15 @@ type XMLReporter struct {
 
 // Report produces a XML report including a summary
 func (x XMLReporter) Report(results []*Result) {
+	c, f := checksAndFailures(results)
 	// silently ignore the errors
 	r := xmlReport{
 		Run:         time.Now(),
 		Since:       since,
 		Version:     VERSION,
 		CompletedIn: toMillisecondsString(totalDuration(results)),
+		Checks:      c,
+		Failures:    f,
 		Results:     buildTaskReports(results),
 	}
 	io.WriteString(x.Writer, xml.Header)
@@ -36,5 +39,7 @@ type xmlReport struct {
 	Since       time.Time    `xml:"since,attr"`
 	Version     string       `xml:"version,attr"`
 	CompletedIn string       `xml:"completedIn,attr"`
+	Checks      int          `xml:"checks,attr"`
+	Failures    int          `xml:"failures,attr"`
 	Results     []taskReport `xml:"results"`
 }


### PR DESCRIPTION
This pull request adds 'metadata' to the XML and JSON reporters. Namely the "checks" and "failures" counts that are at the bottom of the HTML report.

It changes the "Selfdiagnose" struct in the JSON reporter from a `map[string]string` to `map[string]interface{}` so that the JSON encoder will do the correct display transformations.