### PR TITLE
add ReportProcessing task with on-demand goroutine counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 SelfDiagnose
 ==
 
-SelfDiagnose is a package of diagnotistic tasks that can verify the availability of external resources required for the execution of a Go application.
+SelfDiagnose is a package of diagnostic tasks that can verify the availability of external resources 
+required for the execution of a Go application.
 
 This is a simplified port of its [Java implementation](https://github.com/emicklei/selfdiagnose/).
 
 Read the [full documentation](http://godoc.org/github.com/emicklei/go-selfdiagnose)
 
-(c) 2013-2016, http://ernestmicklei.com. Apache v2 License
+(c) 2013-2017, http://ernestmicklei.com. Apache v2 License

--- a/core.go
+++ b/core.go
@@ -7,7 +7,7 @@ package selfdiagnose
 import "time"
 
 // VERSION is used for including it in a report.
-const VERSION = "1.6.7"
+const VERSION = "1.6.8"
 
 var since = time.Now()
 

--- a/task/report_cpu.go
+++ b/task/report_cpu.go
@@ -7,10 +7,21 @@ import (
 	"github.com/emicklei/go-selfdiagnose"
 )
 
+// Deprecated: ReportCPU's active goroutines are only calculated during task registering
 func ReportCPU() selfdiagnose.ReportMessage {
 	cpu := selfdiagnose.ReportMessage{
 		Message: fmt.Sprintf("%d CPU available. %d goroutines active", runtime.NumCPU(), runtime.NumGoroutine()),
 	}
 	cpu.SetComment("Num CPU")
 	return cpu
+}
+
+type ReportProcessing struct{}
+
+func (r ReportProcessing) Comment() string { return "Processing" }
+
+func (c ReportProcessing) Run(ctx *selfdiagnose.Context, result *selfdiagnose.Result) {
+	result.Passed = true
+	result.Reason = fmt.Sprintf("%d CPU available. %d goroutines active on %d golang threads", runtime.NumCPU(), runtime.NumGoroutine(), runtime.GOMAXPROCS(-1))
+	result.Severity = selfdiagnose.SeverityNone
 }


### PR DESCRIPTION
Change-Id: I2337f7b2dd31449097f353a39bccd7d03c3f5bd7

Implements a new task (ReportProcessing) to replace the deprecated (?) ReportCPU task, which would only show the amount of goroutines during registering the task i.e. when your app boots up.